### PR TITLE
feat(useSelectionState): add `isItemSelectable` option

### DIFF
--- a/src/hooks/useSelectionState/useSelectionState.stories.mdx
+++ b/src/hooks/useSelectionState/useSelectionState.stories.mdx
@@ -1,6 +1,11 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import { useSelectionState } from './useSelectionState';
-import { Checkboxes, ExpandableTable, ExternalState } from './useSelectionState.stories.tsx';
+import {
+  Checkboxes,
+  ExpandableTable,
+  ExternalState,
+  NonSelectableItems,
+} from './useSelectionState.stories.tsx';
 import GithubLink from '../../../.storybook/helpers/GithubLink';
 
 <Meta title="Hooks/useSelectionState" component={useSelectionState} />
@@ -23,6 +28,7 @@ interface ISelectionStateArgs<T> {
   items: T[];
   initialSelected?: T[]; // Defaults to []
   isEqual?: (a: T, b: T) => boolean; // Defaults to (a, b) => a === b
+  isItemSelectable?: (item: T) => boolean; // Defaults to () => true
   externalState?: [T[], React.Dispatch<React.SetStateAction<T[]>>];
 }
 
@@ -30,6 +36,7 @@ interface ISelectionStateArgs<T> {
 interface ISelectionState<T> {
   selectedItems: T[];
   isItemSelected: (item: T) => boolean;
+  isItemSelectable: (item: T) => boolean;
   toggleItemSelected: (item: T, isSelecting?: boolean) => void;
   selectMultiple: (items: T[], isSelecting: boolean) => void;
   areAllSelected: boolean;
@@ -51,12 +58,6 @@ By default, this uses referential equality (`===`), which works great if you're 
 However, **if your item objects can change between renders, you need to specify an alternate implementation of the `isEqual` argument.**
 For example, if your items have `id` properties, you can use `isEqual: (a, b) => a.id === b.id`.
 
-## Lifting state to an external scope
-
-If necessary, you can pass the optional `externalState` prop in order to manage the actual selections array itself from outside the hook.
-This may be useful if you need to manage the state as part of a centralized form, but you still want the logic from these methods.
-The type of `externalState` is the same as the array returned from `React.useState` (a tuple of `value` and `setValue`.)
-
 ## Examples
 
 ### Checkboxes
@@ -71,10 +72,29 @@ The type of `externalState` is the same as the array returned from `React.useSta
   <Story story={ExpandableTable} />
 </Canvas>
 
-### Checkboxes with external state
+### Lifting state to an external scope
+
+If necessary, you can pass the optional `externalState` prop in order to manage the actual selections array itself from outside the hook.
+This may be useful if you need to manage the state as part of a centralized form, but you still want the logic from these methods.
+The type of `externalState` is the same as the array returned from `React.useState` (a tuple of `value` and `setValue`.)
 
 <Canvas>
   <Story story={ExternalState} />
+</Canvas>
+
+### Disabling selection of certain items
+
+You can use the optional `isItemSelectable: (item: T) => boolean` callback to control whether an item's selection should be allowed.
+A non-selectable item will not be selected when calling `toggleItemSelected`, `selectMultiple` or `selectAll`,
+and it will be ignored when determining the value of `areAllSelected` (if all _selectable_ items are selected, `areAllSelected` will be `true`).
+
+The same `isItemSelectable` callback you pass in will also be included in the return value object so that it can be easily reused
+for rendering purposes (for example, disabling checkboxes for items that are not selectable) without having to lift it out.
+
+If the selectability of an item changes while it is selected, it will automatically be deselected.
+
+<Canvas>
+  <Story story={NonSelectableItems} />
 </Canvas>
 
 <GithubLink path="src/hooks/useSelectionState/useSelectionState.ts" />

--- a/src/hooks/useSelectionState/useSelectionState.stories.tsx
+++ b/src/hooks/useSelectionState/useSelectionState.stories.tsx
@@ -24,7 +24,7 @@ export const Checkboxes: React.FunctionComponent = () => {
   return (
     <div>
       <Checkbox
-        id="select-all"
+        id="example-1-select-all"
         label="Select all"
         isChecked={areAllSelected}
         onChange={(checked) => selectAll(checked)}
@@ -33,7 +33,7 @@ export const Checkboxes: React.FunctionComponent = () => {
       {fruits.map((fruit) => (
         <Checkbox
           key={fruit.name}
-          id={`${fruit.name}-checkbox`}
+          id={`example-1-${fruit.name}-checkbox`}
           label={fruit.name}
           isChecked={isItemSelected(fruit)}
           onChange={() => toggleItemSelected(fruit)}
@@ -126,7 +126,7 @@ export const ExternalState: React.FunctionComponent = () => {
   return (
     <div>
       <Checkbox
-        id="select-all"
+        id="example-3-select-all"
         label="Select all"
         isChecked={areAllSelected}
         onChange={(checked) => selectAll(checked)}
@@ -135,10 +135,75 @@ export const ExternalState: React.FunctionComponent = () => {
       {fruits.map((fruit) => (
         <Checkbox
           key={fruit.name}
-          id={`${fruit.name}-checkbox`}
+          id={`example-3-${fruit.name}-checkbox`}
           label={fruit.name}
           isChecked={isItemSelected(fruit)}
           onChange={() => toggleItemSelected(fruit)}
+        />
+      ))}
+      {selectedItems.length > 0 ? (
+        <>
+          <br />
+          <p>Do something with these! {selectedItems.map((fruit) => fruit.name).join(', ')}</p>
+        </>
+      ) : null}
+    </div>
+  );
+};
+
+export const NonSelectableItems: React.FunctionComponent = () => {
+  interface IFruit {
+    name: string;
+    isRound: boolean;
+  }
+
+  const fruits: IFruit[] = [
+    { name: 'Apple', isRound: true },
+    { name: 'Orange', isRound: true },
+    { name: 'Banana', isRound: false },
+  ];
+
+  const [nonRoundFruitsAllowed, setNonRoundFruitsAllowed] = React.useState(true);
+
+  const {
+    selectedItems,
+    isItemSelected,
+    isItemSelectable,
+    toggleItemSelected,
+    areAllSelected,
+    selectAll,
+  } = useSelectionState<IFruit>({
+    items: fruits,
+    isEqual: (a, b) => a.name === b.name,
+    isItemSelectable: (item) => item.isRound || nonRoundFruitsAllowed,
+  });
+
+  return (
+    <div>
+      <Checkbox
+        id="allow-non-round"
+        label="Allow non-round fruits"
+        isChecked={nonRoundFruitsAllowed}
+        onChange={setNonRoundFruitsAllowed}
+      />
+      <br />
+      <hr />
+      <br />
+      <Checkbox
+        id="example-4-select-all"
+        label="Select all"
+        isChecked={areAllSelected}
+        onChange={(checked) => selectAll(checked)}
+      />
+      <br />
+      {fruits.map((fruit) => (
+        <Checkbox
+          key={fruit.name}
+          id={`example-4-${fruit.name}-checkbox`}
+          label={fruit.name}
+          isChecked={isItemSelected(fruit)}
+          onChange={() => toggleItemSelected(fruit)}
+          isDisabled={!isItemSelectable(fruit)}
         />
       ))}
       {selectedItems.length > 0 ? (

--- a/src/hooks/useSelectionState/useSelectionState.ts
+++ b/src/hooks/useSelectionState/useSelectionState.ts
@@ -46,27 +46,36 @@ export const useSelectionState = <T>({
     }
   }, [isItemSelectable, selectedItems, setSelectedItems]);
 
-  const toggleItemSelected = (item: T, isSelecting = !isItemSelected(item)) => {
-    if (isSelecting && isItemSelectable(item)) {
-      setSelectedItems([...selectedItems, item]);
-    } else {
-      setSelectedItems(selectedItems.filter((i) => !isEqual(i, item)));
-    }
-  };
+  const toggleItemSelected = React.useCallback(
+    (item: T, isSelecting = !isItemSelected(item)) => {
+      if (isSelecting && isItemSelectable(item)) {
+        setSelectedItems([...selectedItems, item]);
+      } else {
+        setSelectedItems(selectedItems.filter((i) => !isEqual(i, item)));
+      }
+    },
+    [isEqual, isItemSelectable, isItemSelected, selectedItems, setSelectedItems]
+  );
 
-  const selectMultiple = (itemsSubset: T[], isSelecting: boolean) => {
-    const otherSelectedItems = selectedItems.filter(
-      (selected) => !itemsSubset.some((item) => isEqual(selected, item))
-    );
-    const itemsToSelect = itemsSubset.filter(isItemSelectable);
-    if (isSelecting) {
-      setSelectedItems([...otherSelectedItems, ...itemsToSelect]);
-    } else {
-      setSelectedItems(otherSelectedItems);
-    }
-  };
+  const selectMultiple = React.useCallback(
+    (itemsSubset: T[], isSelecting: boolean) => {
+      const otherSelectedItems = selectedItems.filter(
+        (selected) => !itemsSubset.some((item) => isEqual(selected, item))
+      );
+      const itemsToSelect = itemsSubset.filter(isItemSelectable);
+      if (isSelecting) {
+        setSelectedItems([...otherSelectedItems, ...itemsToSelect]);
+      } else {
+        setSelectedItems(otherSelectedItems);
+      }
+    },
+    [isEqual, isItemSelectable, selectedItems, setSelectedItems]
+  );
 
-  const selectAll = (isSelecting = true) => setSelectedItems(isSelecting ? selectableItems : []);
+  const selectAll = React.useCallback(
+    (isSelecting = true) => setSelectedItems(isSelecting ? selectableItems : []),
+    [selectableItems, setSelectedItems]
+  );
   const areAllSelected = selectedItems.length === selectableItems.length;
 
   // Preserve original order of items

--- a/src/hooks/useSelectionState/useSelectionState.ts
+++ b/src/hooks/useSelectionState/useSelectionState.ts
@@ -39,6 +39,13 @@ export const useSelectionState = <T>({
     [isEqual, selectedItems]
   );
 
+  // If isItemSelectable changes and a selected item is no longer selectable, deselect it
+  React.useEffect(() => {
+    if (!selectedItems.every(isItemSelectable)) {
+      setSelectedItems(selectedItems.filter(isItemSelectable));
+    }
+  }, [isItemSelectable, selectedItems, setSelectedItems]);
+
   const toggleItemSelected = (item: T, isSelecting = !isItemSelected(item)) => {
     if (isSelecting && isItemSelectable(item)) {
       setSelectedItems([...selectedItems, item]);


### PR DESCRIPTION
See explanation around the new example in Storybook documentation.

![SiW7FliXuT](https://user-images.githubusercontent.com/811963/188237678-bcec941e-e0c1-4350-925d-aa3a964c5b12.gif)

This PR also attempts to memoize things in `useSelectionState` as much as possible since `.filter()` is called on each render in two places now. Note that this will only help if the consumer passes in stable functions for `isEqual` and `isItemSelectable`, which this example currently doesn't (because it is cumbersome -- you need to use `useCallback` or define the function outside your component). However, these optimizations are unnecessary unless the consumer has a very large number of items. The memoization added in this PR is simply there so that it is possible for the consumer to leverage it if they need to.

We should add explanations in JSDoc/TSDoc comments or some other means where the user can see it via IntelliSense. Opened https://github.com/migtools/lib-ui/issues/113 for that.
